### PR TITLE
Make it compile on Erlang/OTP 20

### DIFF
--- a/src/cuttlefish_unit.erl
+++ b/src/cuttlefish_unit.erl
@@ -1,7 +1,7 @@
 -module(cuttlefish_unit).
 
 -include_lib("eunit/include/eunit.hrl").
--compile(export_all).
+-compile([nowarn_export_all, export_all]).
 
 generate_templated_config(FileName, Conf, Context) ->
     generate_templated_config(FileName, Conf, Context, {[], [], []}).


### PR DESCRIPTION
Ignore the new warning introduced for modules using `export_all`.

I suppose your cuttlefish repo is the canonical one at the moment since Basho went defunct... It's the one we're using at the moment for VerneMQ anyway - hence this PR.