### PR TITLE
Make escript work on OTP20

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
 
 {deps, [getopt, lager]}.
 
-{escript_emu_args, "%%! -escript main cuttlefish_escript -smp disable +A 0\n"}.
+{escript_emu_args, "%%! -escript main cuttlefish_escript +S 1 +A 0\n"}.
 {escript_incl_apps, [goldrush, getopt, lager, cuttlefish]}.
 {escript_main_app, cuttlefish}.
 


### PR DESCRIPTION
Here's another thing I ran into when trying to get VerneMQ running on Erlang/OTP 20. The `-smp` flag has been removed on OTP 20, so I replaced it with `+S 1` instead which should also work on previous versions of Erlang (tried it on OTP 19, 18 and 17). But since I don't know the actual reason for using disabling smp, I don't know if this PR makes sense. Maybe the right thing would be to just remove the `-smp disable` part altogether?