### PR TITLE
Fix tests + enable CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+# vim:sw=2:et:
+
+language: erlang
+sudo: false
+otp_release:
+  - 21.3
+  - 20.3
+  - 19.3
+
+install:
+  - curl -O -L https://s3.amazonaws.com/rebar3/rebar3
+  - chmod +x rebar3
+
+script:
+  - ./rebar3 do compile,eunit,dialyzer
+
+after_success:
+  - ./rebar3 coveralls send
+
+notifications:
+  email:
+    on_success: change
+    on_failure: always
+
+cache:
+  directories:
+    - $HOME/.cache/rebar3/hex/default
+    - $HOME/_build/default/rebar3_${TRAVIS_OTP_RELEASE}_plt

--- a/rebar.config
+++ b/rebar.config
@@ -15,6 +15,8 @@
 
 {eunit_opts, [verbose]}.
 {cover_enabled, true}.
+{cover_print_enabled, true}.
+{cover_export_enabled, true}.
 
 {profiles, [{dev, [{deps, [neotoma]},
                    {plugins, [rebar3_neotoma_plugin]}]},

--- a/rebar.config
+++ b/rebar.config
@@ -17,4 +17,5 @@
 {cover_enabled, true}.
 
 {profiles, [{dev, [{deps, [neotoma]},
-                   {plugins, [rebar3_neotoma_plugin]}]}]}.
+                   {plugins, [rebar3_neotoma_plugin]}]},
+            {test, [{deps, [bbmustache]}]}]}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,15 @@
+%% vim:ft=erlang:
+
+case os:getenv("TRAVIS_JOB_ID") of
+    false -> CONFIG;
+    JobId ->
+        %% coveralls.io.
+        [{plugins, [{coveralls,
+                     {git, "https://github.com/markusn/coveralls-erl",
+                      {branch, "master"}}}]}
+        ,{coveralls_coverdata, "_build/test/cover/eunit.coverdata"}
+        ,{coveralls_service_name, "travis-ci"}
+        ,{coveralls_service_job_id, JobId}
+         |CONFIG
+        ]
+end.

--- a/src/conf_parse.erl
+++ b/src/conf_parse.erl
@@ -62,7 +62,6 @@
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--compile(export_all).
 -endif.
 
 %% @doc Only let through lines that are not comments or whitespace.

--- a/src/conf_parse.erl
+++ b/src/conf_parse.erl
@@ -78,7 +78,7 @@ unescape_dots([C|Rest]) ->
 
 -ifdef(TEST).
 file_test() ->
-    Conf = conf_parse:file("../test/riak.conf"),
+    Conf = conf_parse:file("test/riak.conf"),
     ?assertEqual([
             {["ring_size"],"32"},
             {["anti_entropy"],"debug"},

--- a/src/conf_parse.erl
+++ b/src/conf_parse.erl
@@ -102,7 +102,7 @@ utf8_test() ->
 file(Filename) -> case file:read_file(Filename) of {ok,Bin} -> parse(Bin); Err -> Err end.
 
 -spec parse(binary() | list()) -> any().
-parse(List) when is_list(List) -> parse(list_to_binary(List));
+parse(List) when is_list(List) -> parse(unicode:characters_to_binary(List));
 parse(Input) when is_binary(Input) ->
   _ = setup_memo(),
   Result = case 'config'(Input,{{line,1},{column,1}}) of

--- a/src/conf_parse.peg
+++ b/src/conf_parse.peg
@@ -143,7 +143,7 @@ unescape_dots([C|Rest]) ->
 
 -ifdef(TEST).
 file_test() ->
-    Conf = conf_parse:file("../test/riak.conf"),
+    Conf = conf_parse:file("test/riak.conf"),
     ?assertEqual([
             {["ring_size"],"32"},
             {["anti_entropy"],"debug"},

--- a/src/conf_parse.peg
+++ b/src/conf_parse.peg
@@ -127,7 +127,6 @@ ws <- [ \t] `ws`;
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--compile(export_all).
 -endif.
 
 %% @doc Only let through lines that are not comments or whitespace.

--- a/src/cuttlefish.erl
+++ b/src/cuttlefish.erl
@@ -24,7 +24,6 @@
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--compile(export_all).
 -endif.
 
 -export([

--- a/src/cuttlefish_advanced.erl
+++ b/src/cuttlefish_advanced.erl
@@ -26,7 +26,6 @@
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--compile(export_all).
 -endif.
 
 %% @doc this function overlays the values in proplist 'AdvancedConfig'

--- a/src/cuttlefish_bytesize.erl
+++ b/src/cuttlefish_bytesize.erl
@@ -28,7 +28,6 @@
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--compile(export_all).
 -endif.
 
 -export([parse/1, to_string/1]).

--- a/src/cuttlefish_conf.erl
+++ b/src/cuttlefish_conf.erl
@@ -206,7 +206,6 @@ remove_duplicates(Conf) ->
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--compile(export_all).
 -endif.
 
 -ifdef(TEST).

--- a/src/cuttlefish_conf.erl
+++ b/src/cuttlefish_conf.erl
@@ -297,27 +297,27 @@ generate_comments_test() ->
     ?assertEqual(["## Hi!", "## Bye!", "## ", "## Acceptable values:", "##   - text"], Comments).
 
 duplicates_test() ->
-    Conf = file("../test/multi1.conf"),
+    Conf = file("test/multi1.conf"),
     ?assertEqual(2, length(Conf)),
     ?assertEqual("3", proplists:get_value(["a","b","c"], Conf)),
     ?assertEqual("1", proplists:get_value(["a","b","d"], Conf)),
     ok.
 
 duplicates_multi_test() ->
-    Conf = files(["../test/multi1.conf", "../test/multi2.conf"]),
+    Conf = files(["test/multi1.conf", "test/multi2.conf"]),
     ?assertEqual(2, length(Conf)),
     ?assertEqual("4", proplists:get_value(["a","b","c"], Conf)),
     ?assertEqual("1", proplists:get_value(["a","b","d"], Conf)),
     ok.
 
 files_one_nonent_test() ->
-    Conf = files(["../test/multi1.conf", "../test/nonent.conf"]),
-    ?assertEqual({errorlist,[{error, {file_open, {"../test/nonent.conf", enoent}}}]}, Conf),
+    Conf = files(["test/multi1.conf", "test/nonent.conf"]),
+    ?assertEqual({errorlist,[{error, {file_open, {"test/nonent.conf", enoent}}}]}, Conf),
     ok.
 
 files_incomplete_parse_test() ->
-    Conf = file("../test/incomplete.conf"),
-    ?assertEqual({errorlist, [{error, {conf_syntax, {"../test/incomplete.conf", {3, 1}}}}]}, Conf),
+    Conf = file("test/incomplete.conf"),
+    ?assertEqual({errorlist, [{error, {conf_syntax, {"test/incomplete.conf", {3, 1}}}}]}, Conf),
     ok.
 
 generate_element_level_advanced_test() ->

--- a/src/cuttlefish_datatypes.erl
+++ b/src/cuttlefish_datatypes.erl
@@ -23,7 +23,6 @@
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--compile(export_all).
 -endif.
 
 -type datatype() :: integer |

--- a/src/cuttlefish_duration.erl
+++ b/src/cuttlefish_duration.erl
@@ -28,7 +28,6 @@
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--compile(export_all).
 -endif.
 
 -export([parse/1, parse/2, to_string/2]).

--- a/src/cuttlefish_effective.erl
+++ b/src/cuttlefish_effective.erl
@@ -27,7 +27,6 @@
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--compile(export_all).
 -endif.
 
 -spec build(cuttlefish_conf:conf(), cuttlefish_schema:schema(), [proplists:property()]) -> [string()].

--- a/src/cuttlefish_enum.erl
+++ b/src/cuttlefish_enum.erl
@@ -30,7 +30,6 @@
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--compile(export_all).
 -endif.
 
 -export([

--- a/src/cuttlefish_error.erl
+++ b/src/cuttlefish_error.erl
@@ -37,7 +37,6 @@
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--compile(export_all).
 -endif.
 
 %% We'll be calling this a lot from `xlate'

--- a/src/cuttlefish_escript.erl
+++ b/src/cuttlefish_escript.erl
@@ -27,7 +27,6 @@
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--compile(export_all).
 -endif.
 
 cli_options() ->

--- a/src/cuttlefish_flag.erl
+++ b/src/cuttlefish_flag.erl
@@ -25,7 +25,6 @@
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--compile(export_all).
 -endif.
 
 -export([

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -23,7 +23,6 @@
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--compile(export_all).
 -endif.
 
 -define(FMT(F,A), lists:flatten(io_lib:format(F,A))).

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -721,9 +721,9 @@ add_defaults_test() ->
 
 map_test() ->
     lager:start(),
-    Schema = cuttlefish_schema:file("../test/riak.schema"),
+    Schema = cuttlefish_schema:file("test/riak.schema"),
 
-    Conf = conf_parse:file("../test/riak.conf"),
+    Conf = conf_parse:file("test/riak.conf"),
 
     NewConfig = map(Schema, Conf),
 
@@ -748,7 +748,7 @@ map_test() ->
 
 minimal_map_test() ->
     lager:start(),
-    Schema = cuttlefish_schema:file("../test/riak.schema"),
+    Schema = cuttlefish_schema:file("test/riak.schema"),
     Conf = [{["ring_size"], "32"},
             {["anti_entropy"], "debug"}],
     NewConfig = minimal_map(Schema, Conf),

--- a/src/cuttlefish_mapping.erl
+++ b/src/cuttlefish_mapping.erl
@@ -23,7 +23,6 @@
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--compile(export_all).
 -endif.
 
 -record(mapping, {

--- a/src/cuttlefish_schema.erl
+++ b/src/cuttlefish_schema.erl
@@ -29,9 +29,7 @@
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--compile(export_all).
-
-
+-export([file/1]).
 -endif.
 
 -type schema() :: {

--- a/src/cuttlefish_schema.erl
+++ b/src/cuttlefish_schema.erl
@@ -322,13 +322,13 @@ comment_parser_test() ->
 
 bad_file_test() ->
     cuttlefish_lager_test_backend:bounce(),
-    {errorlist, ErrorList} = file("../test/bad_erlang.schema"),
+    {errorlist, ErrorList} = file("test/bad_erlang.schema"),
 
     Logs = cuttlefish_lager_test_backend:get_logs(),
     [L1|Tail] = Logs,
     [L2|[]] = Tail,
     ?assertMatch({match, _}, re:run(L1, "Error scanning erlang near line 10")),
-    ?assertMatch({match, _}, re:run(L2, "Error parsing schema: ../test/bad_erlang.schema")),
+    ?assertMatch({match, _}, re:run(L2, "Error parsing schema: test/bad_erlang.schema")),
 
     ?assertEqual([
         {error, {erl_scan, 10}}
@@ -375,9 +375,9 @@ files_test() ->
     %% Loads them in reverse order, as things are overridden
     {Translations, Mappings, Validators} = files(
         [
-            "../test/multi1.schema",
-            "../test/multi2.schema",
-            "../test/multi3.schema"
+            "test/multi1.schema",
+            "test/multi2.schema",
+            "test/multi3.schema"
         ]),
 
     ?assertEqual(6, length(Mappings)),

--- a/src/cuttlefish_translation.erl
+++ b/src/cuttlefish_translation.erl
@@ -27,7 +27,7 @@
 
 -record(translation, {
     mapping::string(),
-    func::fun()
+    func::fun() | undefined
     }).
 -type translation() :: #translation{}.
 -type translation_fun() :: fun(([proplists:property()]) -> any()).

--- a/src/cuttlefish_translation.erl
+++ b/src/cuttlefish_translation.erl
@@ -23,7 +23,6 @@
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--compile(export_all).
 -endif.
 
 -record(translation, {

--- a/src/cuttlefish_unit.erl
+++ b/src/cuttlefish_unit.erl
@@ -201,7 +201,7 @@ multiple_schema_generate_templated_config_test() ->
                                 ]})
                         ], []},
 
-    Config = cuttlefish_unit:generate_templated_config("../test/sample_mustache.schema", [], Context, PrereqSchema),
+    Config = cuttlefish_unit:generate_templated_config("test/sample_mustache.schema", [], Context, PrereqSchema),
     lager:error("~p", [Config]),
     assert_config(Config, "app_a.setting_b", "/c/mustache/a.b"),
     ok.

--- a/src/cuttlefish_unit.erl
+++ b/src/cuttlefish_unit.erl
@@ -25,11 +25,20 @@ render_template(FileName, Context) ->
     Str1 = re:replace(Str0, "\"", "\\\\\"", ReOpts),
 
     %% the mustache module is only available in the context of a rebar run.
-    case {code:ensure_loaded(mustache), code:ensure_loaded(rebar_mustache)} of
-        {{module, mustache}, _} ->
+    case {code:ensure_loaded(mustache), code:ensure_loaded(rebar_mustache), code:ensure_loaded(bbmustache)} of
+        {{module, mustache}, _, _} ->
             mustache:render(Str1, dict:from_list(Context));
-        {_, {module, rebar_mustache}} ->
+        {_, {module, rebar_mustache}, _} ->
             rebar_mustache:render(Str1, dict:from_list(Context));
+        {_, _, {module, bbmustache}} ->
+            Ret = bbmustache:render(
+                    Bin,
+                    maps:from_list(
+                      [case is_atom(K) of
+                           true  -> {atom_to_list(K), V};
+                           false -> I
+                       end || I = {K, V} <- Context])),
+            binary_to_list(Ret);
         _ ->
             io:format("mustache and/or rebar_mustache module not loaded. "
                       "This test can only be run in a rebar context.~n")

--- a/src/cuttlefish_util.erl
+++ b/src/cuttlefish_util.erl
@@ -23,7 +23,6 @@
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--compile(export_all).
 -endif.
 
 -export([

--- a/src/cuttlefish_validator.erl
+++ b/src/cuttlefish_validator.erl
@@ -23,7 +23,6 @@
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--compile(export_all).
 -endif.
 
 -record(validator, {

--- a/src/cuttlefish_variable.erl
+++ b/src/cuttlefish_variable.erl
@@ -30,7 +30,6 @@
 -define(QC_OUT(Prop), on_output(fun(F,A) -> io:format(user, F, A) end, Prop)).
 -endif.
 -include_lib("eunit/include/eunit.hrl").
--compile(export_all).
 -endif.
 
 -export([

--- a/src/cuttlefish_vmargs.erl
+++ b/src/cuttlefish_vmargs.erl
@@ -4,7 +4,6 @@
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--compile(export_all).
 -endif.
 
 %% @doc turns a proplist into a list of strings suitable for vm.args files

--- a/test/cuttlefish_escript_integration_tests.erl
+++ b/test/cuttlefish_escript_integration_tests.erl
@@ -1,7 +1,6 @@
 -module(cuttlefish_escript_integration_tests).
 
 -include_lib("eunit/include/eunit.hrl").
--compile(export_all).
 
 escript_utf8_test() ->
     cuttlefish_lager_test_backend:bounce(error),

--- a/test/cuttlefish_escript_integration_tests.erl
+++ b/test/cuttlefish_escript_integration_tests.erl
@@ -6,10 +6,10 @@ escript_utf8_test() ->
     cuttlefish_lager_test_backend:bounce(error),
 
     ?assertThrow(stop_deactivate, cuttlefish_escript:main(
-              "-d ../test_fixtures/escript_utf8_test/generated.config "
-              "-s ../test_fixtures/escript_utf8_test/lib "
-              "-e ../test_fixtures/escript_utf8_test/etc "
-              "-c ../test_fixtures/escript_utf8_test/etc/utf8.conf generate"
+              "-d test_fixtures/escript_utf8_test/generated.config "
+              "-s test_fixtures/escript_utf8_test/lib "
+              "-e test_fixtures/escript_utf8_test/etc "
+              "-c test_fixtures/escript_utf8_test/etc/utf8.conf generate"
             )),
     [Log] = cuttlefish_lager_test_backend:get_logs(),
     ?assertMatch({match, _}, re:run(Log, "utf8.conf: Error converting value on line #1 to latin1")),
@@ -19,13 +19,13 @@ escript_utf8_test() ->
 advanced_config_format_test() ->
     cuttlefish_lager_test_backend:bounce(error),
     ?assertThrow(stop_deactivate, cuttlefish_escript:main(
-                                    "-d ../test_fixtures/acformat/generated.config "
-                                    "-s ../test_fixtures/acformat/lib "
-                                    "-e ../test_fixtures/acformat/etc "
-                                    "-c ../test_fixtures/acformat/etc/acformat.conf generate"
+                                    "-d test_fixtures/acformat/generated.config "
+                                    "-s test_fixtures/acformat/lib "
+                                    "-e test_fixtures/acformat/etc "
+                                    "-c test_fixtures/acformat/etc/acformat.conf generate"
                                    )),
     [Log] = cuttlefish_lager_test_backend:get_logs(),
-    ?assertMatch({match, _}, re:run(Log, "Error parsing [.][.]/test_fixtures/acformat/etc/advanced.config, incorrect format: \\[\\[a\\],\\[b\\]\\]")),
+    ?assertMatch({match, _}, re:run(Log, "Error parsing test_fixtures/acformat/etc/advanced.config, incorrect format: \\[\\[a\\],\\[b\\]\\]")),
     ok.
 
 escript_prune_test_() ->
@@ -37,9 +37,9 @@ escript_prune_test_() ->
 
 escript_prune(DashM, ExpectedMax) ->
     %% Empty workspace
-    case file:list_dir("../test_fixtures/escript_prune_test/generated.config") of
+    case file:list_dir("test_fixtures/escript_prune_test/generated.config") of
         {ok, FilenamesToDelete} ->
-            [ file:delete(filename:join(["../test_fixtures/escript_prune_test/generated.config",F])) || F <- FilenamesToDelete ];
+            [ file:delete(filename:join(["test_fixtures/escript_prune_test/generated.config",F])) || F <- FilenamesToDelete ];
         _ -> ok
     end,
 
@@ -49,20 +49,20 @@ escript_prune(DashM, ExpectedMax) ->
             %% Timer to keep from generating more than one file per second
             timer:sleep(1100),
             cuttlefish_escript:main(
-              "-d ../test_fixtures/escript_prune_test/generated.config "
-              "-s ../test_fixtures/escript_prune_test/lib "
-              "-e ../test_fixtures/escript_prune_test/etc "
+              "-d test_fixtures/escript_prune_test/generated.config "
+              "-s test_fixtures/escript_prune_test/lib "
+              "-e test_fixtures/escript_prune_test/etc "
               ++ DashM ++ " generate"
             ),
 
             AppConfigs =
                 lists:sort(
                     filelib:wildcard("app.*.config",
-                                     "../test_fixtures/escript_prune_test/generated.config")),
+                                     "test_fixtures/escript_prune_test/generated.config")),
             VMArgs =
                 lists:sort(
                     filelib:wildcard("vm.*.args",
-                                     "../test_fixtures/escript_prune_test/generated.config")),
+                                     "test_fixtures/escript_prune_test/generated.config")),
 
             {AppConfigs,
              VMArgs,

--- a/test/cuttlefish_escript_test.erl
+++ b/test/cuttlefish_escript_test.erl
@@ -50,7 +50,7 @@ describe_test_() ->
      ].
 
 describe(Key) ->
-    ?assertThrow(stop_deactivate, cuttlefish_escript:main(["-i", "../test/riak.schema", "-c", "../test/riak.conf", "describe", Key])).
+    ?assertThrow(stop_deactivate, cuttlefish_escript:main(["-i", "test/riak.schema", "-c", "test/riak.conf", "describe", Key])).
 
 describe_prints_docs() ->
     ?capturing(begin
@@ -93,7 +93,7 @@ describe_prints_no_default() ->
 describe_prints_not_configured() ->
     ?capturing(begin
                    describe("ssl.keyfile"),
-                   ?assertPrinted("Value not set in \\.\\./test/riak.conf")
+                   ?assertPrinted("Value not set in test/riak.conf")
                end).
 
 -endif.

--- a/test/cuttlefish_escript_test.erl
+++ b/test/cuttlefish_escript_test.erl
@@ -1,7 +1,6 @@
 -module(cuttlefish_escript_test).
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--compile(export_all).
 
 -define(assertPrinted(___Text),
         begin

--- a/test/cuttlefish_integration_test.erl
+++ b/test/cuttlefish_integration_test.erl
@@ -1,7 +1,6 @@
 -module(cuttlefish_integration_test).
 
 -include_lib("eunit/include/eunit.hrl").
--compile(export_all).
 
 %% This test generates a default .conf file from the riak.schema. view it at ../generated.conf
 generated_conf_file_test() ->

--- a/test/cuttlefish_integration_test.erl
+++ b/test/cuttlefish_integration_test.erl
@@ -2,38 +2,38 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-%% This test generates a default .conf file from the riak.schema. view it at ../generated.conf
+%% This test generates a default .conf file from the riak.schema. view it at generated.conf
 generated_conf_file_test() ->
-    {_, Mappings, _} = cuttlefish_schema:file("../test/riak.schema"),
-    cuttlefish_conf:generate_file(Mappings, "../generated.conf"),
+    {_, Mappings, _} = cuttlefish_schema:file("test/riak.schema"),
+    cuttlefish_conf:generate_file(Mappings, "generated.conf"),
     %% Schema generated a conf file, let's parse it!
-    Conf = cuttlefish_conf:file("../generated.conf"),
+    Conf = cuttlefish_conf:file("generated.conf"),
     ?assertEqual("8099", proplists:get_value(["handoff","port"], Conf)),
     ok.
 
-%% This test generates a .config file from the riak.schema. view it at ../generated.config
+%% This test generates a .config file from the riak.schema. view it at generated.config
 generated_config_file_test() ->
-    Schema = cuttlefish_schema:file("../test/riak.schema"),
-    Conf = [], %% conf_parse:file("../test/riak.conf"),
+    Schema = cuttlefish_schema:file("test/riak.schema"),
+    Conf = [], %% conf_parse:file("test/riak.conf"),
     NewConfig = cuttlefish_generator:map(Schema, Conf),
 
-    file:write_file("../generated.config",io_lib:fwrite("~p.\n",[NewConfig])),
+    file:write_file("generated.config",io_lib:fwrite("~p.\n",[NewConfig])),
     ok.
 
 breaks_on_fuzzy_and_strict_match_test() ->
-    Schema = cuttlefish_schema:file("../test/riak.schema"),
+    Schema = cuttlefish_schema:file("test/riak.schema"),
     Conf = [{["listener", "protobuf", "$name"], "127.0.0.1:8087"}],
     ?assertMatch({error, add_defaults, _}, cuttlefish_generator:map(Schema, Conf)),
     ok.
 
 breaks_on_rhs_not_found_test() ->
-    Schema = cuttlefish_schema:file("../test/riak.schema"),
+    Schema = cuttlefish_schema:file("test/riak.schema"),
     Conf = [{["ring", "state_dir"], "$(tyktorp)/ring"}],
     ?assertMatch({error, rhs_subs, _}, cuttlefish_generator:map(Schema, Conf)),
     ok.
 
 breaks_on_rhs_infinite_loop_test() ->
-    Schema = cuttlefish_schema:file("../test/riak.schema"),
+    Schema = cuttlefish_schema:file("test/riak.schema"),
     Conf = [
             {["ring", "state_dir"], "$(platform_data_dir)/ring"},
             {["platform_data_dir"], "$(ring.state_dir)/data"}
@@ -42,27 +42,27 @@ breaks_on_rhs_infinite_loop_test() ->
     ok.
 
 breaks_on_bad_enum_test() ->
-    Schema = cuttlefish_schema:file("../test/riak.schema"),
+    Schema = cuttlefish_schema:file("test/riak.schema"),
     Conf = [{["storage_backend"], penguin}],
     ?assertMatch({error, transform_datatypes, _}, cuttlefish_generator:map(Schema, Conf)),
     ok.
 
 breaks_on_bad_validation_test() ->
-    Schema = cuttlefish_schema:file("../test/riak.schema"),
+    Schema = cuttlefish_schema:file("test/riak.schema"),
     Conf = [{["ring_size"], 10}],
     ?assertMatch({error, validation, _}, cuttlefish_generator:map(Schema, Conf)),
     ok.
 
 %% Tests that the schema can generate a default app.config from nothing
 all_the_marbles_test() ->
-    Schema = cuttlefish_schema:file("../test/riak.schema"),
-    Conf = [], %conf_parse:file("../test/riak.conf"),
+    Schema = cuttlefish_schema:file("test/riak.schema"),
+    Conf = [], %conf_parse:file("test/riak.conf"),
     NewConfig = cuttlefish_generator:map(Schema, Conf),
     ?assert(is_proplist(NewConfig)),
 
     NewConfigWithoutVmargs = proplists:delete(vm_args, NewConfig),
 
-    {ok, [AppConfig]} = file:consult("../test/default.config"),
+    {ok, [AppConfig]} = file:consult("test/default.config"),
 
     ?assert(is_proplist(AppConfig)),
 
@@ -71,7 +71,7 @@ all_the_marbles_test() ->
 
 multibackend_test() ->
     lager:start(),
-    Schema = cuttlefish_schema:files(["../test/riak.schema", "../test/multi_backend.schema"]),
+    Schema = cuttlefish_schema:files(["test/riak.schema", "test/multi_backend.schema"]),
 
     Conf = [
         {["storage_backend"], "multi"},
@@ -142,7 +142,7 @@ multibackend_test() ->
 
 unset_translation_test() ->
     lager:start(),
-    Schema = cuttlefish_schema:files(["../test/unset_translation.schema"]),
+    Schema = cuttlefish_schema:files(["test/unset_translation.schema"]),
     Conf = [
         {["a", "b"], "8"}
     ],
@@ -153,14 +153,14 @@ unset_translation_test() ->
 
 not_found_error_test() ->
     lager:start(),
-    Schema = cuttlefish_schema:files(["../test/throw_not_found.schema"]),
+    Schema = cuttlefish_schema:files(["test/throw_not_found.schema"]),
     Conf = [],
     NewConfig = cuttlefish_generator:map(Schema, Conf),
     ?assertMatch({error, apply_translations, _}, NewConfig).
 
 duration_test() ->
     lager:start(),
-    Schema = cuttlefish_schema:files(["../test/durations.schema"]),
+    Schema = cuttlefish_schema:files(["test/durations.schema"]),
 
     %% Test that the duration parsing doesn't emit "error" into the
     %% config instead of the extended type.

--- a/test/cuttlefish_nested_schema_test.erl
+++ b/test/cuttlefish_nested_schema_test.erl
@@ -1,7 +1,6 @@
 -module(cuttlefish_nested_schema_test).
 
 -include_lib("eunit/include/eunit.hrl").
--compile(export_all).
 
 nested_schema_test() ->
     Conf = [

--- a/test/cuttlefish_test_group_leader.erl
+++ b/test/cuttlefish_test_group_leader.erl
@@ -24,6 +24,8 @@
          tidy_up/1,
          get_output/0]).
 
+-compile(nowarn_deprecated_function).
+
 %% @doc spawns the new group leader
 new_group_leader(Runner) ->
     spawn_link(?MODULE, group_leader_loop, [Runner, queue:new()]).

--- a/test/erlang_vm_schema_tests.erl
+++ b/test/erlang_vm_schema_tests.erl
@@ -1,7 +1,6 @@
 -module(erlang_vm_schema_tests).
 
 -include_lib("eunit/include/eunit.hrl").
--compile(export_all).
 
 %% basic schema test will check to make sure that all defaults from the schema
 %% make it into the generated app.config

--- a/test/erlang_vm_schema_tests.erl
+++ b/test/erlang_vm_schema_tests.erl
@@ -5,10 +5,10 @@
 %% basic schema test will check to make sure that all defaults from the schema
 %% make it into the generated app.config
 basic_schema_test() ->
-    %% The defaults are defined in ../priv/riak_kv.schema and multi_backend.schema.
+    %% The defaults are defined in priv/riak_kv.schema and multi_backend.schema.
     %% they are the files under test.
     Config = cuttlefish_unit:generate_templated_config(
-        ["../priv/erlang_vm.schema"], [], context()),
+        ["priv/erlang_vm.schema"], [], context()),
 
     cuttlefish_unit:assert_config(Config, "vm_args.-smp", enable),
     cuttlefish_unit:assert_config(Config, "vm_args.+W", "w"),
@@ -64,7 +64,7 @@ override_schema_test() ->
     ],
 
     Config = cuttlefish_unit:generate_templated_config(
-        ["../priv/erlang_vm.schema"], Conf, context()),
+        ["priv/erlang_vm.schema"], Conf, context()),
 
     cuttlefish_unit:assert_config(Config, "vm_args.-smp", disable),
     cuttlefish_unit:assert_config(Config, "vm_args.+W", "i"),
@@ -103,25 +103,25 @@ erlang_scheduler_test() ->
         {["erlang", "schedulers", "online"], 1}
     ],
     Config1 = cuttlefish_unit:generate_templated_config(
-        ["../priv/erlang_vm.schema"], Conf1, context()),
+        ["priv/erlang_vm.schema"], Conf1, context()),
     cuttlefish_unit:assert_config(Config1, "vm_args.+S", "4:1"),
 
     Conf2 = [
         {["erlang", "schedulers", "total"], 4}
     ],
     Config2 = cuttlefish_unit:generate_templated_config(
-        ["../priv/erlang_vm.schema"], Conf2, context()),
+        ["priv/erlang_vm.schema"], Conf2, context()),
     cuttlefish_unit:assert_config(Config2, "vm_args.+S", "4"),
 
     Conf3 = [
         {["erlang", "schedulers", "online"], 4}
     ],
     Config3 = cuttlefish_unit:generate_templated_config(
-        ["../priv/erlang_vm.schema"], Conf3, context()),
+        ["priv/erlang_vm.schema"], Conf3, context()),
     cuttlefish_unit:assert_config(Config3, "vm_args.+S", ":4"),
 
     Config4 = cuttlefish_unit:generate_templated_config(
-        ["../priv/erlang_vm.schema"], [], context()),
+        ["priv/erlang_vm.schema"], [], context()),
     cuttlefish_unit:assert_not_configured(Config4, "vm_args.+S"),
 
 
@@ -138,23 +138,23 @@ async_threads_stack_size_test() ->
     CorrectRaw = 32,
     
     Conf0 = [],
-    Config0 = cuttlefish_unit:generate_templated_config(["../priv/erlang_vm.schema"], Conf0, context()),
+    Config0 = cuttlefish_unit:generate_templated_config(["priv/erlang_vm.schema"], Conf0, context()),
     cuttlefish_unit:assert_not_configured(Config0, "vm_args.+a"),
     
     Conf1 = [{["erlang", "async_threads", "stack_size"], Correct}],
-    Config1 = cuttlefish_unit:generate_templated_config(["../priv/erlang_vm.schema"], Conf1, context()),
+    Config1 = cuttlefish_unit:generate_templated_config(["priv/erlang_vm.schema"], Conf1, context()),
     cuttlefish_unit:assert_config(Config1, "vm_args.+a", CorrectRaw),
 
     Conf2 = [{["erlang", "async_threads", "stack_size"], TooSmall}],
-    Config2 = cuttlefish_unit:generate_templated_config(["../priv/erlang_vm.schema"], Conf2, context()),
+    Config2 = cuttlefish_unit:generate_templated_config(["priv/erlang_vm.schema"], Conf2, context()),
     cuttlefish_unit:assert_error_message(Config2, "erlang.async_threads.stack_size invalid, must be in the range of " ++ MinSize ++ " to " ++ MaxSize),
 
     Conf3 = [{["erlang", "async_threads", "stack_size"], TooLarge}],
-    Config3 = cuttlefish_unit:generate_templated_config(["../priv/erlang_vm.schema"], Conf3, context()),
+    Config3 = cuttlefish_unit:generate_templated_config(["priv/erlang_vm.schema"], Conf3, context()),
     cuttlefish_unit:assert_error_message(Config3, "erlang.async_threads.stack_size invalid, must be in the range of " ++ MinSize ++ " to " ++ MaxSize),
 
     Conf4 = [{["erlang", "async_threads", "stack_size"], Indivisible}],
-    Config4 = cuttlefish_unit:generate_templated_config(["../priv/erlang_vm.schema"], Conf4, context()),
+    Config4 = cuttlefish_unit:generate_templated_config(["priv/erlang_vm.schema"], Conf4, context()),
     cuttlefish_unit:assert_error_message(Config4, "erlang.async_threads.stack_size invalid, must be divisible by " ++ integer_to_list(WordSize)),
 
     ok.
@@ -190,12 +190,12 @@ inet_dist_use_interface_test() ->
 
     lists:foreach(fun({Input, Expected}) ->
                 Config = cuttlefish_unit:generate_templated_config(
-                    ["../priv/erlang_vm.schema"], [{InputConfigPoint, Input}], context()),
+                    ["priv/erlang_vm.schema"], [{InputConfigPoint, Input}], context()),
                 cuttlefish_unit:assert_config(Config, GeneratedConfig, Expected)
         end, Pass),
     lists:foreach(fun(Input) ->
                 Config = cuttlefish_unit:generate_templated_config(
-                    ["../priv/erlang_vm.schema"], [{InputConfigPoint, Input}], context()),
+                    ["priv/erlang_vm.schema"], [{InputConfigPoint, Input}], context()),
                 cuttlefish_unit:assert_error_message(Config,
                     InputConfig ++ " invalid, must be a valid IPv4 or IPv6 address")
         end, Fail).


### PR DESCRIPTION
Before I start to work on and submit the actual change I'm interested in, I wanted to make sure the testsuite was successfull for me.

In this pull request, I made all the changes required to make `rebar3 eunit` and `rebar3 dialyzer` happy. In particular:
* Paths to files and directories in the testcases are relative to the project root directory.
* `bbmustache` is used to render templates.

While here, I added a Travis CI configuration. Here is the result for this branch:
https://travis-ci.com/rabbitmq/cuttlefish

Test coverage is also published to coveralls.io:
https://coveralls.io/github/rabbitmq/cuttlefish

This would allow you to add badges such as:
* [![Build Status](https://travis-ci.com/rabbitmq/cuttlefish.svg?branch=fix-tests)](https://travis-ci.com/rabbitmq/cuttlefish)
* [![Coverage Status](https://coveralls.io/repos/github/rabbitmq/cuttlefish/badge.svg?branch=fix-tests)](https://coveralls.io/github/rabbitmq/cuttlefish)
* [![Hex version](https://img.shields.io/hexpm/v/cuttlefish.svg "Hex version")](https://hex.pm/packages/cuttlefish)