### PR TITLE
cuttlefish.app.src: Bump version to 2.2.0

### DIFF
--- a/src/cuttlefish.app.src
+++ b/src/cuttlefish.app.src
@@ -3,7 +3,7 @@
 {application, cuttlefish,
  [
   {description, "cuttlefish configuration abstraction"},
-  {vsn, git},
+  {vsn, "2.2.0"},
   {registered, []},
   {applications, [
                   kernel,


### PR DESCRIPTION
I would like to publish Cuttlefish 2.2.0 to Hex.pm.

The changes are:
* Lager dependency bumped from 3.6.x to 3.7.x.
* Files are read using `erl_prim_loader:get_file/1`, which means:
    * They can be read from `.ez` archives.
    * Error reporting is uninformative: the function only reports `error`, which is transformed to `{error, udnefined}` so the Cuttlefish return value remains compatible.

I bump the minor version because of the second point mostly.

What do you think?